### PR TITLE
Update match directive

### DIFF
--- a/simple_image_viewer.user.js
+++ b/simple_image_viewer.user.js
@@ -10,6 +10,7 @@
 // @downloadURL    https://github.com/Legend-Master/simple-image-viewer/raw/main/simple_image_viewer.user.js
 // @updateURL      https://github.com/Legend-Master/simple-image-viewer/raw/main/simple_image_viewer.user.js
 // @supportURL     https://github.com/Legend-Master/simple-image-viewer/issues
+// @match          <all_urls>
 // @match          *://*/*
 // @run-at         document-start
 // @grant          none

--- a/simple_image_viewer.user.js
+++ b/simple_image_viewer.user.js
@@ -10,7 +10,7 @@
 // @downloadURL    https://github.com/Legend-Master/simple-image-viewer/raw/main/simple_image_viewer.user.js
 // @updateURL      https://github.com/Legend-Master/simple-image-viewer/raw/main/simple_image_viewer.user.js
 // @supportURL     https://github.com/Legend-Master/simple-image-viewer/issues
-// @match          <all_urls>
+// @match          *://*/*
 // @run-at         document-start
 // @grant          none
 // ==/UserScript==


### PR DESCRIPTION
Update match directive from `<all_urls>` to `*://*/*` so the script works with Tampermonkey

[From their documentation](https://www.tampermonkey.net/documentation.php?locale=en#meta:match):
> Note: the <all_urls> statement is not yet supported